### PR TITLE
Don't include c++utilities for LMDB_SAFE_NO_CPP_UTILITIES builds

### DIFF
--- a/global.h
+++ b/global.h
@@ -1,10 +1,12 @@
-// Created via CMake from template global.h.in
-// WARNING! Any changes to this file will be overwritten by the next CMake run!
-
 #ifndef LMDB_SAFE_GLOBAL
 #define LMDB_SAFE_GLOBAL
 
+#ifndef LMDB_SAFE_NO_CPP_UTILITIES
 #include <c++utilities/application/global.h>
+#else
+#undef LMDB_SAFE_STATIC
+#define LMDB_SAFE_STATIC 1
+#endif
 
 #ifdef LMDB_SAFE_STATIC
 #define LMDB_SAFE_EXPORT


### PR DESCRIPTION
    Don't include c++utilities for LMDB_SAFE_NO_CPP_UTILITIES builds
    
    This is safe for consumers not using shared library packaging
    and improved lmdb-typed.hh.
    
    Removed the comment static that global.h is generated (in this
    project) from a template file, since it is in fact an ordinary
    header file.